### PR TITLE
Update hmmlearn version to make the package compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-	"hmmlearn==0.2.8",
+	"hmmlearn>=0.2.8",
 	"numpy>=1.23.0",
 	"sympy>=1.10.1",
 	"pandas>=1.4.3",


### PR DESCRIPTION
In quite a few environments, the old hmmlearn version is no longer compatible. 